### PR TITLE
Correct how CocoaPods is written in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AlertView A pop-up framework, Can be simple and convenient to join your project.
 - Depend on the project ` Masonry `and ` HexColors ` Import  `#import "Masonry.h"` `#import "HexColors.h"`
 - Import the main header file：`#import "RAlertView.h"`
 
-## cocoapods 
+## CocoaPods 
 `  pod 'RAlertView' `
 
 ## Preview  AlertStyle


### PR DESCRIPTION
See https://github.com/CocoaPods/shared_resources/tree/master/media :)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
